### PR TITLE
Anzeige im Frontend verbessert

### DIFF
--- a/templates/android_index.html
+++ b/templates/android_index.html
@@ -88,15 +88,15 @@
 </div>
 <br />
 <br />
-<strong>Feinstaubwerte und GPS Position:</strong><br />
+<strong>Feinstaubwerte in &micro;g/m<sup>3</sup> und GPS Position:</strong><br />
 
 <table data-role="table" id="table-column-toggle" data-mode="columntoggle" class="ui-responsive table-stroke" style="width: 100%">
      <thead>
        <tr>
-         <th>PM 10</th>
-         <th>PM 25</th>
-         <th>Latitude</th>
-         <th>Longitude</th>
+	 <th>PM<sub>10</sub></th>
+	 <th>PM<sub>2.5</sub></th>
+         <th>geog. Breite</th>
+         <th>geog. Länge</th>
        </tr>
      </thead>
      <tbody>


### PR DESCRIPTION
1. PM 25 zu PM 2.5 korrigiert und 10 und 25 tiefgestellt
2. Einheit microgramm/m³ ergänzt
3. Länge/Breite statt Long./Lat. einheitlich deutsch wie der Rest im Frontend